### PR TITLE
Use SIGINT for KillSignal in systemd example

### DIFF
--- a/docs/subcordant.service
+++ b/docs/subcordant.service
@@ -19,4 +19,5 @@ Environment=DISCORD_BOT_TOKEN=foobar
 Environment=DISCORD_VOICE_CHANNEL_ID=foobar
 Restart=on-failure
 KillMode=control-group
+KillSignal=SIGINT
 TimeoutStopSec=20


### PR DESCRIPTION
When a user runs `systemctl stop subcordant.service` - adding this to the configuration ensures the bot immediately goes offline.